### PR TITLE
Add a new script

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Hassan Abedi
+Copyright (c) 2025 Hassan Abedi
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ This repository contains my dotfiles and other handy files and scripts that I us
 It includes configurations for the following programs:
 
 - **Python-related files**
-  - [pyproject.toml](pyproject.toml)
+    - [pyproject.toml](pyproject.toml)
 - [**Git-related files**](git/)
 - [**Useful scripts**](scripts/)
 - **Editor configurations**
-  - [editorconfig](.editorconfig)
+    - [editorconfig](.editorconfig)
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,15 +10,15 @@ include = ["README.md", "LICENSE"]
 #packages = [{ include = "src", from = "." }]
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.10"
 
 [tool.poetry.dev-dependencies]
 poetry-dynamic-versioning = "^1.4.0"
 pytest = "^8.0.1"
-pytest-cov = "^5.0.0"
+pytest-cov = "^6.0.0"
 pytest-mock = "^3.14.0"
 mypy = "^1.11.1"
-ruff = "^0.7.1"
+ruff = "^0.8.6"
 
 [tool.poetry.scripts]
 cli = "src.cli:main"
@@ -31,7 +31,7 @@ build-backend = "poetry.core.masonry.api"
 pythonpath = ["."]
 
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 ignore_missing_imports = true
 disallow_untyped_calls = true
 strict_optional = true

--- a/scripts/fixgpu.sh
+++ b/scripts/fixgpu.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# The problem: In Ubuntu 24.04 LTS, the NVIDIA Unified Memory module (nvidia_uvm) sometimes fails to work correctly
+# after a suspend (sleep). This script helps to fix the issue by removing and reinserting the module.
+
+# Function to check the status of the last executed command
+check_status() {
+    if [ $? -ne 0 ]; then
+        echo "Error: $1"
+        exit 1
+    fi
+}
+
+# Source: https://github.com/ollama/ollama/issues/3489#issuecomment-2094665760
+# Commented out: Stopping the Ollama snap application
+# echo "Stopping the Ollama snap application..."
+# sudo snap stop ollama
+# check_status "Failed to stop the Ollama snap application."
+
+echo "Attempting to remove the nvidia_uvm module..."
+sudo rmmod nvidia_uvm
+check_status "Failed to remove the nvidia_uvm module."
+
+# Verify if the nvidia_uvm module is still loaded
+if lsmod | grep -q nvidia_uvm; then
+    echo "The nvidia_uvm module is still loaded. Listing processes using /dev/nvidia-uvm..."
+    sudo lsof /dev/nvidia-uvm
+    check_status "Failed to list open files on /dev/nvidia-uvm."
+    echo "Please stop or kill the processes using /dev/nvidia-uvm and rerun the script."
+    exit 1
+fi
+
+echo "Reinserting the nvidia_uvm module..."
+sudo modprobe nvidia_uvm
+check_status "Failed to insert the nvidia_uvm module."
+
+# Commented out: Starting the Ollama snap application
+# echo "Starting the Ollama snap application..."
+# sudo snap start ollama
+# check_status "Failed to start the Ollama snap application."
+
+echo "Displaying NVIDIA graphics card information..."
+nvidia-smi
+check_status "Failed to display NVIDIA graphics card information."
+
+echo -e "\nUseful commands for troubleshooting:"
+echo "1. 'pgrep -fa <pattern>' - Find the process ID and command of a running application by matching a pattern."
+echo "2. 'sudo lsof /dev/nvidia-uvm' - List open files on /dev/nvidia-uvm to identify processes using the nvidia-uvm module."
+echo "3. 'pkill -f <pattern>' - Kill a process using the command pattern found with 'pgrep -fa <pattern>'."


### PR DESCRIPTION
- Added a new script for fixing a problem with the NVIDIA Unified Memory module (nvidia_uvm) in Ubuntu 24.04 LTS.
-  The problem: sometimes fails to work correctly after a suspend (sleep).